### PR TITLE
Rename shiftKey variable to ctrlKey

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ window.addEventListener("load",() => {
             gl.drawArrays(gl.TRIANGLES, 0, 6);
             ctx.clearRect(0,0, MainCanvas.width, MainCanvas.height);
             ctx.drawImage(canvas, 0, 0);
-            if (shiftKey){
+            if (ctrlKey){
                 ctx.fillStyle = "yellow"
                 ctx.strokeStyle = "gray"
                 ctx.beginPath();
@@ -155,7 +155,7 @@ window.addEventListener("load",() => {
                     a = 1.2
                 }
             }
-            if (shiftKey){
+            if (ctrlKey){
                 e.preventDefault()
             }
         })
@@ -167,7 +167,7 @@ window.addEventListener("load",() => {
             MainCanvas.width = w
             MainCanvas.height = h
         })
-        let shiftKey = false
+        let ctrlKey = false
         let _X = 0
         let _Y = 0
         window.addEventListener("keydown",(e) => {
@@ -187,13 +187,13 @@ window.addEventListener("load",() => {
                 _iter = 1
             }
             if (e.key == "Control"){
-                shiftKey = true
+                ctrlKey = true
             }
             document.getElementById("Iteration").innerText = "Iteration:" + _iter
         })
         window.addEventListener("keyup",(e) => {
             if (e.key == "Control"){
-                shiftKey = false
+                ctrlKey = false
             }
         })
         render()


### PR DESCRIPTION
## Summary
- rename `shiftKey` variable to `ctrlKey`
- update event handlers and render logic to use new variable

## Testing
- `node --check index.js`


------
https://chatgpt.com/codex/tasks/task_e_68404f12b9c88322b29623867e245268