### PR TITLE
Fix WebGPU uniform buffer size

### DIFF
--- a/index.js
+++ b/index.js
@@ -320,7 +320,7 @@ window.addEventListener("load",async () => {
         new Float32Array(vertexBuffer.getMappedRange()).set(vertices);
         vertexBuffer.unmap();
 
-        const uniformBufferSize = useDD ? 4 * 12 : 4 * 8;
+        const uniformBufferSize = useDD ? 4 * 16 : 4 * 8;
         const uniformBuffer = device.createBuffer({
             size: uniformBufferSize,
             usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST


### PR DESCRIPTION
## Summary
- allocate 64 bytes for uniforms when double-double precision is used in WebGPU

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68416500b4a483229582839eb4aa7a85